### PR TITLE
support SwiftyBeaver  custom logging format

### DIFF
--- a/Sources/SwiftyBeaverProvider/SwiftyBeaverLogger.swift
+++ b/Sources/SwiftyBeaverProvider/SwiftyBeaverLogger.swift
@@ -41,7 +41,7 @@ extension SwiftyBeaverLogger: ConfigInitializable {
 
         if swiftybeaver["console"]?.bool != nil {
             let console = ConsoleDestination()
-            if let format = swiftybeaver["console_format"]?.string {
+            if let format = swiftybeaver["console_format"]?.string, !format.isEmpty && !format.isNull {
                 console.format = format
             }
             destinations.append(console)
@@ -53,7 +53,7 @@ extension SwiftyBeaverLogger: ConfigInitializable {
             }
 
             let file = FileDestination()  // log to file
-            if let format = swiftybeaver["file_format"]?.string {
+            if let format = swiftybeaver["file_format"]?.string, !format.isEmpty && !format.isNull {
                 file.format = format
             }
             file.logFileURL = URL(fileURLWithPath: path) // set log file

--- a/Sources/SwiftyBeaverProvider/SwiftyBeaverLogger.swift
+++ b/Sources/SwiftyBeaverProvider/SwiftyBeaverLogger.swift
@@ -40,7 +40,11 @@ extension SwiftyBeaverLogger: ConfigInitializable {
         var destinations = [BaseDestination]()
 
         if swiftybeaver["console"]?.bool != nil {
-            destinations.append(ConsoleDestination())
+            let console = ConsoleDestination()
+            if let format = swiftybeaver["console_format"]?.string {
+                console.format = format
+            }
+            destinations.append(console)
         }
 
         if let path = swiftybeaver["file"]?.string {
@@ -49,6 +53,9 @@ extension SwiftyBeaverLogger: ConfigInitializable {
             }
 
             let file = FileDestination()  // log to file
+            if let format = swiftybeaver["file_format"]?.string {
+                file.format = format
+            }
             file.logFileURL = URL(fileURLWithPath: path) // set log file
             destinations.append(file)
         }


### PR DESCRIPTION
Here is an example of a SwiftyBeaver configuration file to set a custom logging format.
```swift
{
    "console":true,
    "console_format":" $Dyyyy-MM-dd HH:mm:ss$d $C$L$c $T $N.$F:$l -> $M",
    "file":"/path/to/log/file",
    "file_format": " $Dyyyy-MM-dd HH:mm:ss$d $C$L$c $T $N.$F:$l -> $M"
}
```
[Learn more](http://docs.swiftybeaver.com/category/19-advanced-topics) about custom logging format. 
PS. You should avoid started with "$" in all values, see the [Vapor docs](https://docs.vapor.codes/2.0/configs/config/#example)