### PR TITLE
[Fix builds] Add macOS 10.12 minimum supported platform version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,11 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "SwiftyBeaverProvider",
+    platforms: [
+        .macOS(.v10_12)
+    ],
     products: [
         .library(name: "SwiftyBeaverProvider", targets: ["SwiftyBeaverProvider"])
     ],

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "SwiftyBeaverProvider",
+    products: [
+        .library(name: "SwiftyBeaverProvider", targets: ["SwiftyBeaverProvider"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),
+        .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver.git", from: "1.6.0")
+    ],
+    targets: [
+        .target(name: "SwiftyBeaverProvider", dependencies: ["SwiftyBeaver", "Vapor"]),
+        .testTarget(name: "SwiftyBeaverProviderTests", dependencies: ["SwiftyBeaverProvider"])
+    ]
+)


### PR DESCRIPTION
This fixes the current build failure due to the dependency `SwiftyBeaver` `1.8.0` also having
this same requirement. This produces the following error message without the change:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/159331/66594780-c8879b80-eb67-11e9-819b-994cc4edf1d0.png">

I first noticed this issue when I updated my project that used this, and it had transitively updated `SwiftyBeaver` to >`1.8.0` which added the `platforms` parameter, thus causing my build to fail. I've temporarily pinned to `.upToNextMinor("1.7.1")` but this is the real fix.

Also updated the tools version which is _required_ to support the `platforms` argument.